### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # flask-components
 [![Build Status](https://travis-ci.org/concordusapps/flask-components.png?branch=master)](https://travis-ci.org/concordusapps/flask-components)
 [![Coverage Status](https://coveralls.io/repos/concordusapps/flask-components/badge.png?branch=master)](https://coveralls.io/r/concordusapps/flask-components?branch=master)
-[![PyPi Version](https://pypip.in/v/Flask-Components/badge.png)](https://pypi.python.org/pypi/Flask-Components)
-![PyPi Downloads](https://pypip.in/d/Flask-Components/badge.png)
+[![PyPi Version](https://img.shields.io/pypi/v/Flask-Components.svg)](https://pypi.python.org/pypi/Flask-Components)
+![PyPi Downloads](https://img.shields.io/pypi/dm/Flask-Components.svg)
 > A simple flask extension to discover files in a declared array of components.
 
 ## License


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20flask-components))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `flask-components`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.